### PR TITLE
fix: JEI recipe lookup no longer shows all subtypes

### DIFF
--- a/src/main/java/net/darkhax/resourcehogs/ResourceHogs.java
+++ b/src/main/java/net/darkhax/resourcehogs/ResourceHogs.java
@@ -53,23 +53,22 @@ public class ResourceHogs {
 
     public static Block truffle;
 
-    public Item spawner;
-    public Item mudBucket;
+    public static Item spawner;
+    public static Item mudBucket;
     public static Item bacon;
 
     @EventHandler
     public void preInit (FMLPreInitializationEvent event) {
-
         ModConfiguration.syncConfigData();
         
         // Load all of the entries. Not constructed yet though.
         ResourceRegistry.loadResourceEntries();
 
-        this.spawner = REGISTRY.registerItem(new ItemPigSpawner(), "spawner").setHasSubtypes(true);
+        spawner = REGISTRY.registerItem(new ItemPigSpawner(), "spawner").setHasSubtypes(true);
         REGISTRY.registerMob(EntityResourceHog.class, "resourcehog", 0, 0x123321, 0xab03bf);
         truffle = REGISTRY.registerBlock(new BlockTruffle(), "truffle");
         bacon = REGISTRY.registerItem(new ItemBacon(), "bacon").setHasSubtypes(true);
-        this.mudBucket = REGISTRY.registerItem(new ItemMudBucket(), "mud_bucket").setHasSubtypes(true);
+        mudBucket = REGISTRY.registerItem(new ItemMudBucket(), "mud_bucket").setHasSubtypes(true);
 
         MinecraftForge.EVENT_BUS.register(this);
     }

--- a/src/main/java/net/darkhax/resourcehogs/compat/jei/JEIPlugin.java
+++ b/src/main/java/net/darkhax/resourcehogs/compat/jei/JEIPlugin.java
@@ -1,0 +1,33 @@
+package net.darkhax.resourcehogs.compat.jei;
+
+import mezz.jei.api.IModPlugin;
+import mezz.jei.api.ISubtypeRegistry;
+import mezz.jei.api.ISubtypeRegistry.ISubtypeInterpreter;
+import net.darkhax.resourcehogs.ResourceHogs;
+import net.minecraft.item.Item;
+import net.minecraft.nbt.NBTTagCompound;
+
+@mezz.jei.api.JEIPlugin
+public class JEIPlugin implements IModPlugin {
+    private static final String RESOURCE_TYPE_TAG = "ResourceType";
+
+    @Override
+    public void registerItemSubtypes(ISubtypeRegistry registry) {
+        ISubtypeInterpreter interpreter = (stack) -> {
+            final NBTTagCompound tag = stack.getTagCompound();
+            if (tag == null) {
+                return "";
+            }
+            if (!tag.hasKey(RESOURCE_TYPE_TAG)) {
+                return "";
+            }
+
+            return tag.getString(RESOURCE_TYPE_TAG);
+        };
+        registry.registerSubtypeInterpreter(ResourceHogs.bacon, interpreter);
+        registry.registerSubtypeInterpreter(ResourceHogs.spawner, interpreter);
+        registry.registerSubtypeInterpreter(ResourceHogs.mudBucket, interpreter);
+        registry.registerSubtypeInterpreter(Item.getItemFromBlock(ResourceHogs.truffle),
+                interpreter);
+    }
+}


### PR DESCRIPTION
When looking up recipes for an item or the uses of an item in JEI, all subtypes of the item used to show rather than just the one resourcetype version as intended.

This resolves it by registering a JEI subtype interpreter.